### PR TITLE
svn.cpp: Do not call svn_fs_copied_from on delete

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -565,9 +565,13 @@ int SvnRevision::exportEntry(const char *key, const svn_fs_path_change_t *change
     QString current = QString::fromUtf8(key);
 
     // was this copied from somewhere?
-    svn_revnum_t rev_from;
-    const char *path_from;
-    SVN_ERR(svn_fs_copied_from(&rev_from, &path_from, fs_root, key, revpool));
+    svn_revnum_t rev_from = SVN_INVALID_REVNUM;
+    const char *path_from = NULL;
+    if (change->change_kind != svn_fs_path_change_delete) {
+        // svn_fs_copied_from would fail on deleted paths, because the path
+        // obviously no longer exists in the current revision
+        SVN_ERR(svn_fs_copied_from(&rev_from, &path_from, fs_root, key, revpool));
+    }
 
     // is this a directory?
     svn_boolean_t is_dir;


### PR DESCRIPTION
I have no idea where the appropriate upstream for this code currently is, since Gitorious seems to be unreachable at the moment and will soon be read-only. Let me know if you have a better idea of where to push this code.

When converting the MacPorts Subversion repository to Git, the conversion fails at revision 8:

```
Exporting revision 8 svn: E160013: File not found: revision 8, path '/trunk/base/Tcl/pkgIndex.tcl'
```

I'm not sure whether the offending call to `svn_fs_copied_from` worked in earlier versions of Subversion. For the record, my copy was built against Subversion 1.9.2. My solution for the problem is not calling `svn_fs_copied_from` for deleted files (because their history must obviously be where they are deleted anyway, you cannot (or can you, but why would you) copy a file and delete it in the same commit).
